### PR TITLE
添加 DSH Studio

### DIFF
--- a/website_info.csv
+++ b/website_info.csv
@@ -142,5 +142,4 @@ Url,Name,Description,Tag
 "https://jellyfin.org/","jellyfin","一个开源的媒体管理软件,可以管理硬盘中的音乐,电影,连续剧,并生成照片墙","极客;"
 "https://www.speedrun.com/","SpeedRun","游戏速通网站", "游戏;信息流;在线工具;"
 "https://www.applegamingwiki.com/","AppleGamingWiki","收集macOS能玩的游戏,以及兼容情况","游戏;信息流;"
-
 "https://github.com/Moresyl/dsh-studio","DSH Studio","开源本地优先的跨平台 DeepSeek Harness 桌面管理器，统一管理安装、运行状态、日志和进程生命周期","AI;极客;开源资讯;"

--- a/website_info.csv
+++ b/website_info.csv
@@ -142,3 +142,5 @@ Url,Name,Description,Tag
 "https://jellyfin.org/","jellyfin","一个开源的媒体管理软件,可以管理硬盘中的音乐,电影,连续剧,并生成照片墙","极客;"
 "https://www.speedrun.com/","SpeedRun","游戏速通网站", "游戏;信息流;在线工具;"
 "https://www.applegamingwiki.com/","AppleGamingWiki","收集macOS能玩的游戏,以及兼容情况","游戏;信息流;"
+
+"https://github.com/Moresyl/dsh-studio","DSH Studio","开源本地优先的跨平台 DeepSeek Harness 桌面管理器，统一管理安装、运行状态、日志和进程生命周期","AI;极客;开源资讯;"


### PR DESCRIPTION
按照 README 的贡献说明，在 `website_info.csv` 末尾加入 DSH Studio：

- URL：https://github.com/Moresyl/dsh-studio
- 分类：`AI;极客;开源资讯;`
- 项目仓库与 Releases 均已验证可访问
- 仅新增一个 CSV 条目

DSH Studio 是开源、本地优先的跨平台 DeepSeek Harness 桌面管理器，将安装、启动停止、健康检查、运行日志和进程清理集中到一个桌面界面，并通过 GitHub Actions 发布 Windows、macOS 和 Linux 安装包。

披露：我是项目维护者，属于开源自荐。